### PR TITLE
Fix mask

### DIFF
--- a/contracts/CommandBuilder.sol
+++ b/contracts/CommandBuilder.sol
@@ -256,7 +256,7 @@ library CommandBuilder {
         uint256 idx = uint256(uint8(index));
         if (idx == IDX_END_OF_ARGS) return;
 
-        bytes memory entry = state[idx] = new bytes(output.length + 32);
+        bytes memory entry = state[idx & IDX_VALUE_MASK] = new bytes(output.length + 32);
         memcpy(output, 0, entry, 32, output.length);
         assembly {
             let l := mload(output)


### PR DESCRIPTION
Fixes an issue where the IDX points to variable length data and therefore has a mask. Since it doesn't get unmasked it point to an out-of-bounds location in state.